### PR TITLE
fix: resolve error in application initialization

### DIFF
--- a/awviz/src/main.cpp
+++ b/awviz/src/main.cpp
@@ -14,10 +14,9 @@
 
 #include <awviz_common/viewer.hpp>
 
-#include <iostream>
-
-int main()
+int main(int argc, char ** argv)
 {
-  std::cout << "Hello, awviz!!" << std::endl;
+  rclcpp::init(argc, argv);
   awviz_common::ViewerApp app;
+  app.run();
 }

--- a/awviz_common/include/awviz_common/viewer.hpp
+++ b/awviz_common/include/awviz_common/viewer.hpp
@@ -40,6 +40,11 @@ public:
    */
   ~ViewerApp();
 
+  /**
+   * @brief Start running application.
+   */
+  void run();
+
 private:
   rclcpp::Node::SharedPtr node_;
   std::shared_ptr<rerun::RecordingStream> stream_;

--- a/awviz_common/src/viewer.cpp
+++ b/awviz_common/src/viewer.cpp
@@ -18,6 +18,8 @@
 #include "rclcpp/utilities.hpp"
 #include "rerun/recording_stream.hpp"
 
+#include <rclcpp/executors.hpp>
+
 #include <memory>
 
 namespace awviz_common
@@ -33,5 +35,10 @@ ViewerApp::ViewerApp()
 ViewerApp::~ViewerApp()
 {
   rclcpp::shutdown();
+}
+
+void ViewerApp::run()
+{
+  rclcpp::spin(node_);
 }
 }  // namespace awviz_common


### PR DESCRIPTION
## What

Resolve exception in application initialization.

```shell
terminate called after throwing an instance of 'rclcpp::exceptions::RCLInvalidArgument'
  what():  failed to create guard condition: context argument is null, at ./src/rcl/guard_condition.c:65
[ros2run]: Aborted
```