### PR TITLE
feat: add an option to print usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ source install/setup.bash
 
 ### Run
 
+To see the usage, run `awviz -h`.
+
 ```shell
 # run awviz
 awviz

--- a/awviz/src/main.cpp
+++ b/awviz/src/main.cpp
@@ -13,9 +13,26 @@
 // limitations under the License.
 
 #include <awviz_common/viewer.hpp>
+#include <rerun/third_party/cxxopts.hpp>
+
+#include <string>
 
 int main(int argc, char ** argv)
 {
+  cxxopts::Options options("awviz", "A 3D ROS viewer for Autoware powered by Rerun.");
+  // clang-format off
+  options.add_options()
+    ("h,help", "Print usage.")
+  ;
+  // clang-format on
+
+  auto args = options.parse(argc, argv);
+
+  if (args.count("help")) {
+    std::cout << options.help() << std::endl;
+    exit(0);
+  }
+
   rclcpp::init(argc, argv);
   awviz_common::ViewerApp app;
   app.run();

--- a/docs/MAIN.md
+++ b/docs/MAIN.md
@@ -20,6 +20,8 @@ source install/setup.bash
 
 ### Run
 
+To see the usage, run `awviz -h`.
+
 ```shell
 # run awviz
 awviz


### PR DESCRIPTION
## Description

Add an option to print usage.

## How was this PR tested?

```shell
$ awviz -h
A 3D ROS viewer for Autoware powered by Rerun.
Usage:
  awviz [OPTION...]

  -h, --help  Print usage.
```

## Notes for reviewers

None.

## Effects on system behavior

None.
