### PR TITLE
feat(plugin): add guard to block zero size image

### DIFF
--- a/awviz_plugin/src/image/camera_info_display.cpp
+++ b/awviz_plugin/src/image/camera_info_display.cpp
@@ -27,6 +27,11 @@ CameraInfoDisplay::CameraInfoDisplay()
 
 void CameraInfoDisplay::log_message(sensor_msgs::msg::CameraInfo::ConstSharedPtr msg)
 {
+  if (msg->width == 0 || msg->height == 0) {
+    log_warning_text(property_.topic() + " has zero resolution");
+    return;
+  }
+
   log_timestamp(rclcpp::Time(msg->header.stamp.sec, msg->header.stamp.nanosec));
 
   const auto entity_path = resolve_entity_path(msg->header.frame_id, false);

--- a/awviz_plugin/src/image/compressed_image_display.cpp
+++ b/awviz_plugin/src/image/compressed_image_display.cpp
@@ -44,6 +44,11 @@ void CompressedImageDisplay::log_message(sensor_msgs::msg::CompressedImage::Cons
   try {
     const auto & rgb = cv_bridge::toCvCopy(msg, "rgb8")->image;
 
+    if (rgb.empty() || rgb.cols == 0 || rgb.rows == 0) {
+      log_warning_text(property_.topic() + " decoded to an empty image");
+      return;
+    }
+
     stream_->log(
       entity_path.value(), rerun::Image::from_rgb24(rgb, rerun::WidthHeight(rgb.cols, rgb.rows)));
   } catch (const cv_bridge::Exception & e) {

--- a/awviz_plugin/src/image/image_display.cpp
+++ b/awviz_plugin/src/image/image_display.cpp
@@ -40,6 +40,11 @@ void ImageDisplay::log_message(sensor_msgs::msg::Image::ConstSharedPtr msg)
   try {
     const auto & rgb = cv_bridge::toCvCopy(msg, "rgb8")->image;
 
+    if (rgb.empty() || rgb.cols == 0 || rgb.rows == 0) {
+      log_warning_text(property_.topic() + " decoded to an empty image");
+      return;
+    }
+
     stream_->log(
       entity_path.value(), rerun::Image::from_rgb24(rgb, rerun::WidthHeight(rgb.cols, rgb.rows)));
   } catch (const cv_bridge::Exception & e) {


### PR DESCRIPTION
## Description

This pull request introduces validation checks to ensure image messages have valid resolutions before processing or logging them. The main goal is to prevent downstream errors and provide clear warnings when invalid or empty images are encountered.

Validation and warning improvements:

* Added a check in `CameraInfoDisplay::log_message()` to warn and return early if the `CameraInfo` message has zero width or height, indicating an invalid resolution.
* Added checks in both `ImageDisplay::log_message()` and `CompressedImageDisplay::log_message()` to warn and return early if the decoded image is empty or has zero rows or columns, preventing logging of invalid image data. [[1]](diffhunk://#diff-ba7dcdd0c14db5bbc041a548042226c8515c066109a93aa973f990d6033d0362R43-R47) [[2]](diffhunk://#diff-5101b130d97444e5fd0bd0abf2a7bae263a5bac445c09e42daec197bbd1ebc97R47-R51)

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
